### PR TITLE
All seen Tiles included

### DIFF
--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/world/WorldImpl.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/world/WorldImpl.java
@@ -93,10 +93,8 @@ public class WorldImpl extends World {
 
     for (int i = viewBox.northLimitHeight; i <= viewBox.southLimitHeight; ++i) {
       for (int j = viewBox.westLimitWidth; j <= viewBox.eastLimitWidth; ++j) {
-        Tile tile = tiles[i][j];
-        if (position.getH() != i && position.getW() != j) {
-          list.add(tile);
-        }
+
+        list.add(tiles[i][j]);
       }
     }
 


### PR DESCRIPTION
This branch fixes the List of Tiles collected in the `viewSight` method of the `World`,
because it was not complete.

The only change is that there should not be any condition checked to add a Tile to the List,
because the bounds of the cycles already set which Tiles can be seen by a given Entity.