### PR TITLE
OrderedList insertion fix

### DIFF
--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/util/OrderedList.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/util/OrderedList.java
@@ -70,6 +70,6 @@ public class OrderedList<E extends Ordered> {
       }
     }
 
-    return FIRST;
+    return backingList.size();
   }
 }


### PR DESCRIPTION
The `add` method in `OrderedList` contained a crucial error. When there were only element with smaller order in the list than the order of the one we want to add, originally it'd be placed at the beginning of the list.

This PR fixes this issue by placing such elements at the end of the list.