### PR TITLE
Add resources to EntityManager

### DIFF
--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/ContentModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/ContentModule.java
@@ -5,6 +5,7 @@ import io.infectnet.server.engine.content.type.BitResourceTypeComponent;
 import io.infectnet.server.engine.content.type.NestTypeComponent;
 import io.infectnet.server.engine.content.world.customizer.NestCustomizer;
 import io.infectnet.server.engine.core.entity.Entity;
+import io.infectnet.server.engine.core.entity.EntityCreator;
 import io.infectnet.server.engine.core.entity.EntityManager;
 import io.infectnet.server.engine.core.entity.component.TypeComponent;
 import io.infectnet.server.engine.core.entity.type.TypeRepository;
@@ -29,9 +30,8 @@ public class ContentModule {
   @Provides
   @Singleton
   public static Function<Player, Player> providesDefaultPlayerInitializer(
-      PlayerStorageService playerStorageService, EntityManager entityManager,
-      World world, TypeRepository typeRepository,
-      NestCustomizer nestCustomizer) {
+      PlayerStorageService playerStorageService, TypeRepository typeRepository,
+      NestCustomizer nestCustomizer, EntityCreator entityCreator) {
     return (player) -> {
       playerStorageService.addStorageForPlayer(player);
 
@@ -39,20 +39,11 @@ public class ContentModule {
         storage.setAttribute(BitResourceTypeComponent.TYPE_NAME, 50);
       });
 
-      Optional<TypeComponent> typeComponent =
-          typeRepository.getTypeByName(NestTypeComponent.TYPE_NAME);
+      Optional<TypeComponent> nestType = typeRepository.getTypeByName(NestTypeComponent.TYPE_NAME);
 
-      if (typeComponent.isPresent()) {
-        Entity nest = typeComponent.get().createEntityOfType();
-
-        nest.getOwnerComponent().setOwner(player);
-
+      if (nestType.isPresent()) {
         nestCustomizer.getRandomNestPosition().ifPresent(pos -> {
-          nest.getPositionComponent().setPosition(pos);
-
-          world.getTileByPosition(pos).setEntity(nest);
-
-          entityManager.addEntity(nest);
+          entityCreator.create(nestType.get(), pos, player);
         });
       }
 

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/SystemModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/SystemModule.java
@@ -8,6 +8,7 @@ import io.infectnet.server.engine.content.system.inventory.InventoryManagementSy
 import io.infectnet.server.engine.content.system.kill.KillSystem;
 import io.infectnet.server.engine.content.system.movement.MovementSystem;
 import io.infectnet.server.engine.content.system.spawn.SpawnSystem;
+import io.infectnet.server.engine.core.entity.EntityCreator;
 import io.infectnet.server.engine.core.entity.EntityManager;
 import io.infectnet.server.engine.core.entity.type.TypeRepository;
 import io.infectnet.server.engine.core.player.storage.PlayerStorageService;
@@ -77,7 +78,8 @@ public class SystemModule {
   @IntoSet
   public static ProcessorSystem providesEntityCreatorSystem(EntityManager entityManager,
                                                             World world,
-                                                            PlayerStorageService playerStorageService) {
-    return new EntityCreatorSystem(entityManager, world, playerStorageService);
+                                                            PlayerStorageService playerStorageService,
+                                                            EntityCreator entityCreator) {
+    return new EntityCreatorSystem(entityManager, world, playerStorageService, entityCreator);
   }
 }

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/WorldModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/WorldModule.java
@@ -2,6 +2,7 @@ package io.infectnet.server.engine.content.configuration;
 
 import io.infectnet.server.engine.content.world.customizer.NestCustomizer;
 import io.infectnet.server.engine.content.world.customizer.ResourceCustomizer;
+import io.infectnet.server.engine.core.entity.EntityCreator;
 import io.infectnet.server.engine.core.entity.type.TypeRepository;
 import io.infectnet.server.engine.core.player.PlayerService;
 import io.infectnet.server.engine.core.util.hook.Hook;
@@ -21,8 +22,9 @@ public class WorldModule {
   @Provides
   @Singleton
   public static ResourceCustomizer providesResourceCustomizer(TypeRepository typeRepository,
-                                                              PlayerService playerService) {
-    return new ResourceCustomizer(typeRepository, playerService);
+                                                              PlayerService playerService,
+                                                              EntityCreator entityCreator) {
+    return new ResourceCustomizer(typeRepository, playerService, entityCreator);
   }
 
   @Provides

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/world/customizer/ResourceCustomizer.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/world/customizer/ResourceCustomizer.java
@@ -2,6 +2,7 @@ package io.infectnet.server.engine.content.world.customizer;
 
 import io.infectnet.server.engine.content.type.BitResourceTypeComponent;
 import io.infectnet.server.engine.core.entity.Entity;
+import io.infectnet.server.engine.core.entity.EntityCreator;
 import io.infectnet.server.engine.core.entity.component.TypeComponent;
 import io.infectnet.server.engine.core.entity.type.TypeRepository;
 import io.infectnet.server.engine.core.player.Player;
@@ -44,13 +45,18 @@ public class ResourceCustomizer implements WorldCustomizer {
 
   private final PlayerService playerService;
 
+  private final EntityCreator entityCreator;
+
   private TypeComponent component;
 
   private Player environmentPlayer;
 
-  public ResourceCustomizer(TypeRepository typeRepository, PlayerService playerService) {
+  public ResourceCustomizer(TypeRepository typeRepository, PlayerService playerService, EntityCreator entityCreator) {
     this.typeRepository = typeRepository;
+
     this.playerService = playerService;
+
+    this.entityCreator = entityCreator;
   }
 
   @Override
@@ -116,12 +122,7 @@ public class ResourceCustomizer implements WorldCustomizer {
    */
   private void addingResourcesToWorld(World world, List<Position> resources) {
     for (Position pos : resources) {
-      Entity resource = component.createEntityOfType();
-
-      resource.getPositionComponent().setPosition(pos);
-      resource.getOwnerComponent().setOwner(environmentPlayer);
-
-      world.getTileByPosition(pos).setEntity(resource);
+      entityCreator.create(component, pos, environmentPlayer);
     }
 
     logger.info("Added {} resource entities to world", resources.size());

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/configuration/EntityModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/configuration/EntityModule.java
@@ -1,5 +1,6 @@
 package io.infectnet.server.engine.core.configuration;
 
+import io.infectnet.server.engine.core.entity.EntityCreator;
 import io.infectnet.server.engine.core.entity.EntityManager;
 import io.infectnet.server.engine.core.entity.EntityManagerImpl;
 import io.infectnet.server.engine.core.entity.component.TypeComponent;
@@ -9,6 +10,7 @@ import io.infectnet.server.engine.core.entity.wrapper.EntityWrapper;
 import io.infectnet.server.engine.core.entity.wrapper.EntityWrapperFactory;
 import io.infectnet.server.engine.core.entity.wrapper.EntityWrapperRepository;
 import io.infectnet.server.engine.core.entity.wrapper.EntityWrapperRepositoryImpl;
+import io.infectnet.server.engine.core.world.World;
 
 import java.util.Collections;
 import java.util.Map;
@@ -46,5 +48,11 @@ public abstract class EntityModule {
   @ElementsIntoSet
   public static Set<TypeComponent> providesDefaultEmptyTypeComponentSet() {
     return Collections.emptySet();
+  }
+
+  @Provides
+  @Singleton
+  public static EntityCreator providesEntityCreator(EntityManager entityManager, World world) {
+    return new EntityCreator(entityManager, world);
   }
 }

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/entity/EntityCreator.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/entity/EntityCreator.java
@@ -1,0 +1,61 @@
+package io.infectnet.server.engine.core.entity;
+
+import io.infectnet.server.engine.core.entity.component.TypeComponent;
+import io.infectnet.server.engine.core.player.Player;
+import io.infectnet.server.engine.core.world.Position;
+import io.infectnet.server.engine.core.world.World;
+
+import java.util.Objects;
+
+/**
+ * Helper class for creating {@link Entity} objects and storing them in a {@link World} and
+ * {@link EntityManager} instance.
+ */
+public class EntityCreator {
+  private final EntityManager entityManager;
+
+  private final World world;
+
+  /**
+   * Constructs a new instance that will place created {@code Entity} objects in the specified
+   * parameters.
+   * @param entityManager the {@code EntityManager} that will manage the {@code Entity}
+   * @param world the {@code World} the {@code Entity} is placed on
+   */
+  public EntityCreator(EntityManager entityManager, World world) {
+    this.entityManager = entityManager;
+    
+    this.world = world;
+  }
+
+  /**
+   * Creates a new {@code Entity} instance with the given type. The newly created object will have
+   * its owner and position set to be the passed parameters and will be added to the {@code World}
+   * and the {@code EntityManager} instance this {@code EntityCreator} was constructed with.
+   * <p>
+   * Note that this method may throw any exception that can occur during the creation process.
+   * </p>
+   * @param type the type that will construct the new {@code Entity}
+   * @param position the starting position of the {@code Entity}
+   * @param owner the owner of the {@code Entity}
+   * @return the newly created {@code Entity} object
+   * @throws NullPointerException If the value of a parameter is {@code null}. In that case, no
+   * {@code Entity} will be created.
+   */
+  public Entity create(TypeComponent type, Position position, Player owner) {
+    TypeComponent nonNullType = Objects.requireNonNull(type);
+    Position nonNullPosition = Objects.requireNonNull(position);
+    Player nonNullOwner = Objects.requireNonNull(owner);
+
+    Entity entity = nonNullType.createEntityOfType();
+
+    entity.getPositionComponent().setPosition(nonNullPosition);
+    entity.getOwnerComponent().setOwner(nonNullOwner);
+
+    entityManager.addEntity(entity);
+
+    world.getTileByPosition(nonNullPosition).setEntity(entity);
+
+    return entity;
+  }
+}

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/entity/EntityCreator.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/entity/EntityCreator.java
@@ -54,7 +54,7 @@ public class EntityCreator {
 
     entityManager.addEntity(entity);
 
-    world.getTileByPosition(nonNullPosition).setEntity(entity);
+    world.setEntityOnPosition(entity, nonNullPosition);
 
     return entity;
   }

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/entity/EntityCreator.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/entity/EntityCreator.java
@@ -24,7 +24,7 @@ public class EntityCreator {
    */
   public EntityCreator(EntityManager entityManager, World world) {
     this.entityManager = entityManager;
-    
+
     this.world = world;
   }
 


### PR DESCRIPTION
The resources generate by `ResourceCustomizer` were not added to the `EntityManager`. This issue is solved by this fix.

Additionally, an `EntityCreator` helper class is introduced, so all the nitty-gritty details of entity creation can happen in one place