### PR TITLE
Movement system rework

### DIFF
--- a/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/traits/MoveTrait.groovy
+++ b/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/traits/MoveTrait.groovy
@@ -3,12 +3,23 @@ package io.infectnet.server.engine.content.traits
 import groovy.transform.SelfType
 import io.infectnet.server.engine.content.system.movement.MovementAction
 import io.infectnet.server.engine.core.entity.wrapper.EntityWrapper
+import io.infectnet.server.engine.core.world.Position
 
 @SelfType(EntityWrapper)
 trait MoveTrait {
 
   void moveTo(EntityWrapper target) {
-    this.actionConsumer.accept(this.state, new MovementAction(this.wrappedEntity, Objects.requireNonNull(target).wrappedEntity));
+    this.actionConsumer.accept(this.state, new MovementAction(this.wrappedEntity,
+        Objects.requireNonNull(target).wrappedEntity.getPositionComponent().getPosition()));
   }
 
+  void moveTo(Position target) {
+    this.actionConsumer.accept(this.state, new MovementAction(this.wrappedEntity,
+        Objects.requireNonNull(target)));
+  }
+
+  void moveTo(int x, int y) {
+    this.actionConsumer.accept(this.state, new MovementAction(this.wrappedEntity,
+        new Position(y, x)));
+  }
 }

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/system/movement/MovementAction.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/system/movement/MovementAction.java
@@ -2,18 +2,19 @@ package io.infectnet.server.engine.content.system.movement;
 
 import io.infectnet.server.engine.core.entity.Entity;
 import io.infectnet.server.engine.core.entity.wrapper.Action;
+import io.infectnet.server.engine.core.world.Position;
 
 public class MovementAction extends Action {
 
-  private final Entity targetEntity;
+  private final Position targetPosition;
 
-  public MovementAction(Entity movingEntity, Entity targetEntity) {
+  public MovementAction(Entity movingEntity, Position targetPosition) {
     super(movingEntity);
 
-    this.targetEntity = targetEntity;
+    this.targetPosition = targetPosition;
   }
 
-  public Entity getTargetEntity() {
-    return targetEntity;
+  public Position getTargetPosition() {
+    return targetPosition;
   }
 }

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/system/movement/MovementSystem.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/system/movement/MovementSystem.java
@@ -38,7 +38,7 @@ public class MovementSystem implements ProcessorSystem {
     MovementAction movementAction = (MovementAction) action;
 
     Position startPosition = movementAction.getSource().getPositionComponent().getPosition();
-    Position targetPosition = movementAction.getTargetEntity().getPositionComponent().getPosition();
+    Position targetPosition = movementAction.getTargetPosition();
 
     // If the target position occupied and we are next to it, don't move.
     if (world.getTileByPosition(targetPosition).isBlockedOrOccupied()

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/system/movement/MovementSystem.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/system/movement/MovementSystem.java
@@ -7,7 +7,10 @@ import io.infectnet.server.engine.core.script.Request;
 import io.infectnet.server.engine.core.system.ProcessorSystem;
 import io.infectnet.server.engine.core.util.ListenableQueue;
 import io.infectnet.server.engine.core.world.Position;
+import io.infectnet.server.engine.core.world.Tile;
 import io.infectnet.server.engine.core.world.World;
+
+import java.util.List;
 
 public class MovementSystem implements ProcessorSystem {
 
@@ -37,7 +40,16 @@ public class MovementSystem implements ProcessorSystem {
     Position startPosition = movementAction.getSource().getPositionComponent().getPosition();
     Position targetPosition = movementAction.getTargetEntity().getPositionComponent().getPosition();
 
-    Position nextPosition = world.findPath(startPosition, targetPosition).get(0).getPosition();
+    // If the target position occupied and we are next to it, don't move.
+    if (world.getTileByPosition(targetPosition).isBlockedOrOccupied()
+        && startPosition.getNeighbours().contains(targetPosition)) {
+      return;
+    }
+    List<Tile> path = world.findPath(startPosition, targetPosition);
+
+    // Because the path is returned in reversed order we need the last but one position.
+    // The last position in the path is the entity's current position.
+    Position nextPosition = path.get(path.size() - 2).getPosition();
 
     requestQueue.add(new MovementRequest(movementAction.getSource(), movementAction, nextPosition));
   }
@@ -49,10 +61,13 @@ public class MovementSystem implements ProcessorSystem {
     // This is enforced by the constructor.
     Entity movementTarget = movementRequest.getTarget().get();
 
-    world.setEntityOnPosition(null, movementTarget.getPositionComponent().getPosition());
+    if (!world.getTileByPosition(movementRequest.getPosition()).isBlockedOrOccupied()) {
+      world.setEntityOnPosition(null, movementTarget.getPositionComponent().getPosition());
 
-    world.setEntityOnPosition(movementTarget, movementRequest.getPosition().stepSouth());
+      world.setEntityOnPosition(movementTarget, movementRequest.getPosition());
 
-    movementTarget.getPositionComponent().setPosition(movementRequest.getPosition());
+      movementTarget.getPositionComponent().setPosition(movementRequest.getPosition());
+    }
+
   }
 }


### PR DESCRIPTION
Entities were teleporting to the target position instead of moving normally one tile at a tick.
This issue was caused by the reversed order of the path returned by the World's PathFinderStrategy.

This pull request fixes choosing the next position for the moving entity.

Additional small security checks were added to prevent moving entities overwriting
each other.