### PR TITLE
DSL visibility fix

### DIFF
--- a/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/dsl/GatherBlock.groovy
+++ b/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/dsl/GatherBlock.groovy
@@ -15,6 +15,9 @@ class GatherBlock implements DslBindingCustomizer {
           for (T element : elements) {
             def closureDelegate = [current: element];
 
+            closureDelegate.putAll(
+                (Map) filter.thisObject.properties["binding"].properties["variables"]);
+
             filter.delegate = closureDelegate;
 
             if (filter()) {


### PR DESCRIPTION
Visibility in nested closures did not work as intended - they've either lost their `current` variable or the variables passed as the `Script`'s `Binding`.

This PR fixes this issue by copying variables passed to the closure's `thisObject` onto the closure's `delegate` and then setting the resolution strategy to `DELEGATE_FIRST`. 