### PR TITLE
Move DslBindingCustomizer to engine.core

### DIFF
--- a/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/dsl/GatherBlock.groovy
+++ b/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/dsl/GatherBlock.groovy
@@ -1,6 +1,7 @@
 package io.infectnet.server.engine.content.dsl
 
 import groovy.transform.CompileStatic
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer
 import io.infectnet.server.engine.core.script.execution.BindingContext
 
 @CompileStatic

--- a/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/dsl/SelectFilterActionBlock.groovy
+++ b/server-core/engine/src/main/groovy/io/infectnet/server/engine/content/dsl/SelectFilterActionBlock.groovy
@@ -1,6 +1,7 @@
 package io.infectnet.server.engine.content.dsl
 
 import groovy.transform.CompileStatic
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer
 import io.infectnet.server.engine.core.script.execution.BindingContext
 
 @CompileStatic

--- a/server-core/engine/src/main/groovy/io/infectnet/server/engine/core/dsl/DslBindingCustomizer.groovy
+++ b/server-core/engine/src/main/groovy/io/infectnet/server/engine/core/dsl/DslBindingCustomizer.groovy
@@ -1,4 +1,4 @@
-package io.infectnet.server.engine.content.dsl
+package io.infectnet.server.engine.core.dsl
 
 import io.infectnet.server.engine.core.script.execution.BindingContext
 

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/DslModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/DslModule.java
@@ -1,6 +1,6 @@
 package io.infectnet.server.engine.content.configuration;
 
-import io.infectnet.server.engine.content.dsl.DslBindingCustomizer;
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer;
 import io.infectnet.server.engine.content.dsl.GatherBlock;
 import io.infectnet.server.engine.content.dsl.PlayerStorageDslCustomizer;
 import io.infectnet.server.engine.content.dsl.SelectFilterActionBlock;

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/SelectorModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/configuration/SelectorModule.java
@@ -1,6 +1,6 @@
 package io.infectnet.server.engine.content.configuration;
 
-import io.infectnet.server.engine.content.dsl.DslBindingCustomizer;
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer;
 import io.infectnet.server.engine.content.player.Environment;
 import io.infectnet.server.engine.content.selector.EnemySelectorFactory;
 import io.infectnet.server.engine.content.selector.EnvironmentSelectorFactory;

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/content/dsl/PlayerStorageDslCustomizer.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/content/dsl/PlayerStorageDslCustomizer.java
@@ -1,5 +1,6 @@
 package io.infectnet.server.engine.content.dsl;
 
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer;
 import io.infectnet.server.engine.core.player.storage.PlayerStorage;
 import io.infectnet.server.engine.core.player.storage.PlayerStorageService;
 import io.infectnet.server.engine.core.script.execution.BindingContext;

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/configuration/ScriptModule.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/configuration/ScriptModule.java
@@ -3,7 +3,7 @@ package io.infectnet.server.engine.core.configuration;
 import groovy.lang.Binding;
 import io.infectnet.server.engine.content.configuration.DslModule;
 import io.infectnet.server.engine.content.configuration.SelectorModule;
-import io.infectnet.server.engine.content.dsl.DslBindingCustomizer;
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer;
 import io.infectnet.server.engine.core.player.Player;
 import io.infectnet.server.engine.core.script.code.CodeRepository;
 import io.infectnet.server.engine.core.script.code.CodeRepositoryImpl;

--- a/server-core/engine/src/main/java/io/infectnet/server/engine/core/script/selector/SelectorFactory.java
+++ b/server-core/engine/src/main/java/io/infectnet/server/engine/core/script/selector/SelectorFactory.java
@@ -1,6 +1,6 @@
 package io.infectnet.server.engine.core.script.selector;
 
-import io.infectnet.server.engine.content.dsl.DslBindingCustomizer;
+import io.infectnet.server.engine.core.dsl.DslBindingCustomizer;
 import io.infectnet.server.engine.core.player.Player;
 import io.infectnet.server.engine.core.script.execution.BindingContext;
 


### PR DESCRIPTION
The `DslBindingCustomizer` was placed in the `engine.content` package instead of `engine.core`. In this PR I've put the class into the `engine.core` package.